### PR TITLE
Adding build configuration for usage string, fixes #25

### DIFF
--- a/resource-impl/pom.xml
+++ b/resource-impl/pom.xml
@@ -39,11 +39,6 @@
 		</dependency>
         <dependency>
 			<groupId>org.nmdp.service</groupId>
-            <artifactId>epitope-resource</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-			<groupId>org.nmdp.service</groupId>
             <artifactId>epitope-service</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -13,6 +13,8 @@
     <properties>
         <dsh-compress.version>1.0</dsh-compress.version>
         <dsh-commandline.version>1.1</dsh-commandline.version>
+        <maven.build.timestamp>${maven.build.timestamp}</maven.build.timestamp>
+        <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -80,6 +82,17 @@
                         <id>filter-src</id>
                         <goals>
                             <goal>filter-sources</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/tools/src/main/java-templates/org/nmdp/service/epitope/tools/About.java
+++ b/tools/src/main/java-templates/org/nmdp/service/epitope/tools/About.java
@@ -33,9 +33,9 @@ import java.io.PrintStream;
 final class About {
     private static final String ARTIFACT_ID = "${project.artifactId}";
     private static final String BUILD_TIMESTAMP = "${maven.build.timestamp}";
-    private static final String COMMIT = "TBD";
+    private static final String COMMIT = "${git.commit.id}";
     private static final String COPYRIGHT = "Copyright (c) 2015 National Marrow Donor Program (NMDP)";
-    private static final String LICENSE = "TBD";
+    private static final String LICENSE = "Licensed GNU Lesser General Public License (LGPL), version 3 or later";
     private static final String VERSION = "${project.version}";
 
 


### PR DESCRIPTION
```bash
$ epitope-alleles -a
epitope-tools 0.0.1-SNAPSHOT
Commit: 9b7b26f2607883a9e53b86450b38446de05974b1  Build: 2015-03-12
Copyright (c) 2015 National Marrow Donor Program (NMDP)
Licensed GNU Lesser General Public License (LGPL), version 3 or later
```